### PR TITLE
Fixed code sample: RoleCenterId is by reference

### DIFF
--- a/Modules/System/Default Role Center/README.md
+++ b/Modules/System/Default Role Center/README.md
@@ -4,7 +4,7 @@ Example
 
 ```
 [EventSubscriber(ObjectType::Codeunit, Codeunit::"Default Role Center", 'OnBeforeGetDefaultRoleCenter', '', false, false)]
-local procedure SetRoleCenter(RoleCenterId: Integer; var Handled: Boolean)
+local procedure SetRoleCenter(var RoleCenterId: Integer; var Handled: Boolean)
 begin
     // Do not overwrite already defined default role center
     if Handled then


### PR DESCRIPTION
There is a mismatch between the code example and the API definition few lines below.